### PR TITLE
Add wwwroot placeholder to avoid static asset errors

### DIFF
--- a/src/Server/Server.csproj
+++ b/src/Server/Server.csproj
@@ -23,6 +23,7 @@
     <Content Include="..\WebUI\dist\**\*" CopyToPublishDirectory="PreserveNewest">
       <Link>wwwroot\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
+    <Content Remove="wwwroot/.gitkeep" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add empty wwwroot directory with .gitkeep to satisfy Static Web Assets
- exclude placeholder file from static web asset content

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d838d088832faa8da5b952f3aad7